### PR TITLE
golangのバージョンを1.19.4へアップデート

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.2-bullseye as builder
+FROM golang:1.19.4-bullseye as builder
 
 WORKDIR /go/src
 COPY go.mod .


### PR DESCRIPTION
脆弱性対応のためGoを1.19.4へアップデート