### PR TITLE
chore: use nonroot image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.19.4-bullseye as builder
+ARG GO_VERSION 1.19.4
+
+FROM golang:${GO_VERSION}-bullseye as builder
 
 WORKDIR /go/src
 COPY go.mod .
@@ -8,9 +10,8 @@ RUN go mod download
 COPY . /go/src
 RUN go build -o prism-api
 
-FROM gcr.io/distroless/base-debian11:latest
+FROM gcr.io/distroless/base-debian11:nonroot
 
 COPY --from=builder --chown=nonroot:nonroot /go/src/prism-api /bin/prism-api
 
-USER nonroot
 ENTRYPOINT [ "/bin/prism-api" ]


### PR DESCRIPTION
- Docker imageをnonrootに変更した
- GoのバージョンをARGにして更新がほんの少し楽になった